### PR TITLE
refactor!: simplify internals and harden validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/quver/VATIdValidator.git", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/quver/VATIdValidator.git", .upToNextMajor(from: "2.0.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 [![GitHub license](https://img.shields.io/github/license/quver/VATIdValidator.svg)]()
 [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg)](https://swift.org/package-manager)
 [![codebeat badge](https://codebeat.co/badges/a96882e8-2953-4453-8734-cbc6edb9c16c)](https://codebeat.co/projects/github-com-quver-vatidvalidator-master)
-[![codecov](https://codecov.io/gh/quver/VATIdValidator/branch/master/graph/badge.svg)](https://codecov.io/gh/quver/VATIdValidator)
-[![Readme Score](http://readme-score-api.herokuapp.com/score.svg?url=https://github.com/quver/vatidvalidator)](http://clayallsopp.github.io/readme-score?url=https://github.com/quver/vatidvalidator)
-[![Documentation](https://quver.github.io/VATIdValidator/badge.svg)](https://quver.github.io/VATIdValidator/index.html)
+[![codecov](https://codecov.io/gh/quver/VATIdValidator/branch/main/graph/badge.svg)](https://codecov.io/gh/quver/VATIdValidator)
 
 Polish VAT Identification (NIP) number validator.
+
+## Requirements
+- iOS 13+ / macOS 10.15+ / tvOS 13+ / watchOS 7+
+- Swift 6.1+
+- Xcode 16.4+
 
 ## API
 ### Initialisation
@@ -17,7 +20,7 @@ Polish VAT Identification (NIP) number validator.
 VATIdValidator([Int])
 VATIdValidator(BinaryInteger)
 VATIdValidator(Double)
-VATIdValidator(StringLiteralType)
+VATIdValidator(String)
 ```
 ### Validation
 ```swift
@@ -27,7 +30,7 @@ try validator.validate()
 ### Extensions
 - BinaryInteger
 - Double
-- StringLiteralType
+- String
 
 ```swift
 var isValidVATId: Bool { get }

--- a/Sources/VATIdValidator/VATIdValidator.swift
+++ b/Sources/VATIdValidator/VATIdValidator.swift
@@ -2,8 +2,9 @@ public struct VATIdValidator {
 
     /**
      ## Possible validation errors.
-     
+
       - `incorrectLength` - The VAT identifier should have 10 digits.
+      - `invalidDigit` - Each element must be a single digit (0–9).
       - `checkSumNotMatch` - Checksum should be equal 10th digit of the VAT Identifier.
      */
     public enum ValidationError: Error {
@@ -11,13 +12,15 @@ public struct VATIdValidator {
         /// The VAT Identifier should have 10 digits.
         case incorrectLength
 
+        /// Each element must be a single digit (0–9).
+        case invalidDigit
+
         /// Checksum should be equal 10th digit of the VAT ID.
         case checkSumNotMatch
 
     }
 
-    let vatId: [Int?]
-    private let filteredVATId: [Int]
+    private let digits: [Int]
     private let vatIdLength = 10
 
     /**
@@ -25,8 +28,7 @@ public struct VATIdValidator {
      - Parameter vatId: The VAT identifier as array of integers.
      */
     public init(_ vatId: [Int]) {
-        self.vatId = vatId
-        self.filteredVATId = vatId.compactMap { $0 }
+        self.digits = vatId
     }
 
     /**
@@ -49,9 +51,8 @@ public struct VATIdValidator {
      Common constructor.
      - Parameter vatId: The VAT identifier as string.
      */
-    public init(_ vatId: StringLiteralType) {
-        self.vatId = vatId.map { Int(String($0)) }
-        filteredVATId = self.vatId.compactMap { $0 }
+    public init(_ vatId: String) {
+        self.digits = vatId.compactMap { $0.wholeNumberValue }
     }
 
     /**
@@ -62,25 +63,25 @@ public struct VATIdValidator {
      */
     public func validate() throws {
         // The VAT identifier should have 10 digits.
-        guard vatId.count == vatIdLength
-            && filteredVATId.count == vatIdLength else { throw ValidationError.incorrectLength }
+        guard digits.count == vatIdLength else { throw ValidationError.incorrectLength }
+
+        // Each digit must be in range 0–9.
+        guard digits.allSatisfy({ (0...9).contains($0) }) else { throw ValidationError.invalidDigit }
 
         // Checksum should be equal 10th digit of the VAT identifier.
-        guard checkSum() == vatId[9] else { throw ValidationError.checkSumNotMatch }
+        guard checkSum() == digits[9] else { throw ValidationError.checkSumNotMatch }
     }
 
-    func checkSum() -> Int? {
-        guard vatId.count == vatIdLength && filteredVATId.count == vatIdLength else { return nil }
-
-        return (6 * filteredVATId[0] +
-            5 * filteredVATId[1] +
-            7 * filteredVATId[2] +
-            2 * filteredVATId[3] +
-            3 * filteredVATId[4] +
-            4 * filteredVATId[5] +
-            5 * filteredVATId[6] +
-            6 * filteredVATId[7] +
-            7 * filteredVATId[8]) % 11
+    private func checkSum() -> Int {
+        return (6 * digits[0] +
+            5 * digits[1] +
+            7 * digits[2] +
+            2 * digits[3] +
+            3 * digits[4] +
+            4 * digits[5] +
+            5 * digits[6] +
+            6 * digits[7] +
+            7 * digits[8]) % 11
     }
 
 }
@@ -94,7 +95,7 @@ public extension BinaryInteger {
 
 }
 
-public extension StringLiteralType {
+public extension String {
 
     /**
     Is valid VAT identifier.

--- a/Tests/VATIdValidatorTests/VATIdValidatorTests.swift
+++ b/Tests/VATIdValidatorTests/VATIdValidatorTests.swift
@@ -28,95 +28,46 @@ struct VATIdValidatorTests {
 
     // MARK: - Init
 
-    @Test func initWithIntArray() {
-        let validator = VATIdValidator([5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithIntArray() throws {
+        try VATIdValidator([5, 2, 6, 0, 2, 5, 0, 2, 7, 4]).validate()
     }
 
-    @Test func initWithInt() {
-        let validator = VATIdValidator(Int(5260250274))
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithInt() throws {
+        try VATIdValidator(Int(5260250274)).validate()
     }
 
-    @Test func initWithInt64() {
-        let validator = VATIdValidator(Int64(5260250274))
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithInt64() throws {
+        try VATIdValidator(Int64(5260250274)).validate()
     }
 
-    @Test func initWithUInt() {
-        let validator = VATIdValidator(UInt(5260250274))
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithUInt() throws {
+        try VATIdValidator(UInt(5260250274)).validate()
     }
 
-    @Test func initWithUInt64() {
-        let validator = VATIdValidator(UInt64(5260250274))
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithUInt64() throws {
+        try VATIdValidator(UInt64(5260250274)).validate()
     }
 
-    @Test func initWithDouble() {
-        let validator = VATIdValidator(Double(5260250274))
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
+    @Test func initWithDouble() throws {
+        try VATIdValidator(Double(5260250274)).validate()
     }
 
-    @Test func initWithString() {
-        let validator = VATIdValidator("5260250274")
-
-        #expect(validator.vatId == [5, 2, 6, 0, 2, 5, 0, 2, 7, 4])
-    }
-
-    // MARK: - Check sum
-
-    @Test func checksumMinistryOfFinanceVATId() {
-        let validator = VATIdValidator(5260250274)
-
-        #expect(validator.checkSum() == 4)
-    }
-
-    @Test func checksumChancelleryOfThePrimeMinisterVATId() {
-        let validator = VATIdValidator(5261645000)
-
-        #expect(validator.checkSum() == 0)
-    }
-
-    @Test(arguments: [
-        "472052062",
-        "47205206251",
-        "AS4720520625",
-        "4720520625AS",
-        "4720AS520625",
-        "AS47205206",
-        "4720AS0625",
-        "47205206AS"
-    ])
-    func checksumWithInvalidVATId(vatId: String) {
-        #expect(VATIdValidator(vatId).checkSum() == nil)
+    @Test func initWithString() throws {
+        try VATIdValidator("5260250274").validate()
     }
 
     // MARK: - Validation
 
     @Test func validationMinistryOfFinanceVATId() throws {
-        let validator = VATIdValidator(5260250274)
-
-        try validator.validate()
+        try VATIdValidator(5260250274).validate()
     }
 
     @Test func validationChancelleryOfThePrimeMinisterVATId() throws {
-        let validator = VATIdValidator(5261645000)
-
-        try validator.validate()
+        try VATIdValidator(5261645000).validate()
     }
 
     @Test(arguments: [
         "47205206251",
-        "AS4720520625",
-        "4720520625AS",
-        "4720AS520625",
         "AS47205206",
         "4720AS0625",
         "47205206AS"
@@ -128,10 +79,46 @@ struct VATIdValidatorTests {
     }
 
     @Test(arguments: [
+        [1, 2, 3, 4, 5, 6, 7, 8, 99, 0],
+        [5, 2, 6, 0, 2, 5, 0, 2, -1, 4]
+    ])
+    func validationWithInvalidDigit(digits: [Int]) {
+        #expect(throws: ValidationError.invalidDigit) {
+            try VATIdValidator(digits).validate()
+        }
+    }
+
+    // Digits stripped from dashes/spaces yield a valid VAT ID — validate() passes
+    @Test(arguments: [
+        "526-025-02-74",
+        "526 025 02 74",
+        "52-60-25-02-74",
+        "5260 250274"
+    ])
+    func validationWithDashesAndSpacesValid(vatId: String) throws {
+        try VATIdValidator(vatId).validate()
+    }
+
+    // Digits stripped from dashes/spaces yield an invalid VAT ID — checksum mismatch
+    @Test(arguments: [
+        "472-052-06-25",
+        "472 052 0625",
+        "47-20-52-06-25"
+    ])
+    func validationWithDashesAndSpacesInvalid(vatId: String) {
+        #expect(throws: ValidationError.checkSumNotMatch) {
+            try VATIdValidator(vatId).validate()
+        }
+    }
+
+    @Test(arguments: [
         "4720520625",
         "9329704956",
         "9488688496",
-        "9783051521"
+        "9783051521",
+        "AS4720520625",
+        "4720520625AS",
+        "4720AS520625"
     ])
     func validationWithCheckSumNotMatch(vatId: String) {
         #expect(throws: ValidationError.checkSumNotMatch) {
@@ -149,11 +136,11 @@ struct VATIdValidatorTests {
         #expect(!4720520625.isValidVATId)
     }
 
-    @Test func stringLiteralTypeExtensionIsValidTrue() {
+    @Test func stringExtensionIsValidTrue() {
         #expect("5260250274".isValidVATId)
     }
 
-    @Test func stringLiteralTypeExtensionIsValidFalse() {
+    @Test func stringExtensionIsValidFalse() {
         #expect(!"4720520625".isValidVATId)
     }
 


### PR DESCRIPTION
  - Replace dual vatId:[Int?]/filteredVATId:[Int] with single private digits:[Int]
  - Add ValidationError.invalidDigit for [Int] init with out-of-range elements
  - Change StringLiteralType to String in init and extension
  - Make checkSum() private, return Int instead of Int?
  - Use Character.wholeNumberValue instead of Int(String($0)) in String init
  - Update README: requirements section, fix codecov badge branch

  BREAKING CHANGE: extension StringLiteralType replaced by extension String;
  internal vatId and checkSum() no longer accessible via @testable import